### PR TITLE
Make keys persistent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "launchdarkly-js-client-sdk": "^2.20.0",
         "launchdarkly-node-server-sdk": "^6.2.0",
         "launchdarkly-react-client-sdk": "^2.23.3",
+        "local-storage": "^2.0.0",
         "react": "^17.0.2",
         "react-device-detect": "^2.1.2",
         "react-dom": "^17.0.2",
@@ -13088,6 +13089,11 @@
       "engines": {
         "node": ">=8.9.0"
       }
+    },
+    "node_modules/local-storage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/local-storage/-/local-storage-2.0.0.tgz",
+      "integrity": "sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw=="
     },
     "node_modules/locate-path": {
       "version": "5.0.0",
@@ -31207,6 +31213,11 @@
         "emojis-list": "^3.0.0",
         "json5": "^2.1.2"
       }
+    },
+    "local-storage": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/local-storage/-/local-storage-2.0.0.tgz",
+      "integrity": "sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw=="
     },
     "locate-path": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "launchdarkly-js-client-sdk": "^2.20.0",
     "launchdarkly-node-server-sdk": "^6.2.0",
     "launchdarkly-react-client-sdk": "^2.23.3",
+    "local-storage": "^2.0.0",
     "react": "^17.0.2",
     "react-device-detect": "^2.1.2",
     "react-dom": "^17.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,17 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 import { asyncWithLDProvider } from "launchdarkly-react-client-sdk";
 import { deviceType, osName } from "react-device-detect";
-import {v4 as uuidv4} from 'uuid';
+import getUserId from "./util/getUserId";
 
 const CLIENTKEY = "609ead905193530d7c28647b";
 
-let uuid = uuidv4();
+let id = getUserId();
 
 (async () => {
   const LDProvider = await asyncWithLDProvider({
     clientSideID: CLIENTKEY,
     user: {
-      key: uuid,
+      key: id,
       //dynamically set these custom attributes using the deviceType and osName selectors from the npm package
       custom: {
         device: deviceType,

--- a/src/util/getUserId.js
+++ b/src/util/getUserId.js
@@ -1,0 +1,15 @@
+import {v4 as uuidv4} from 'uuid';
+import ls from 'local-storage';
+
+function getUserId() {
+  let id;
+  if (ls.get('LD_User_Key')) {
+    id = ls.get('LD_User_Key');
+  } else {
+    id = uuidv4();
+    ls.set('LD_User_Key', id)
+  }
+  return id;
+}
+
+export default getUserId;


### PR DESCRIPTION
Another small enhancement :)

I plan on maybe using this app for percentage rollout demos. As I was practicing, I noticed that users weren't "sticking" to their buckets. In `index.js` it was generating a new UUID (and thus a new user key) on each page load, which is no bueno for my use case. I included a `getUserId()` call to check localStorage for `LD_User_Key`, and if it exists, use that for the user key. If not, it generates a UUID like before. 

This has the side effect of looking a little more realistic if you were to show the customer your code - most people would probably be doing something abstract like `getUserId` in real life to get their key.

As always, open to feedback if you have any!