### PR TITLE
Upate required Terraform version to match the terraform repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ terraform {
       version = "~> 2.5"
     }
   }
-  required_version = "~> 1.1.7"
+  required_version = "~> 1.1.6"
 }
 
 variable "access_token" {


### PR DESCRIPTION
I'm not totally sure this change is safe, but it allowed me to follow the instructions in the README to get a new project scaffolded with the same flags.

The updated version here aligns the required terraform version in this repo with the version required in [`launchdarkly/terraform`](https://github.com/launchdarkly/terraform/blob/main/.terraform-version#L1) (which presumably lots of folks already have set up).