### PR TITLE
Include release_new_ui as prereq, set show_qr_code desktop targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you want to create a new project with all the right flags, then you can eithe
    2. An API access token with `Writer` permissions. Go to the [Authorizations](https://app.launchdarkly.com/settings/authorization) page to create it.
    3. Terraform installed
 1. See the `terraform.tfvars.example` file in the root directory? Rename it to `terraform.tfvars`.
-1. Then edit the `terraform.tfvars` file, replacing the `access_token` and `project_key` values.
+1. Then edit the `terraform.tfvars` file, replacing the `access_token`, `project_key`, `environment_key`, `customer_logo_url`, `other_logo_url`, and `qr_code_os_targets` values.
 1. Run: `terraform init` to initialize the configuration
 1. Run: `terraform plan`
 1. If that ran with no errors, then run: `terraform apply`

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,21 @@ variable "project_key" {
   type = string
 }
 
+variable "environment_key" {
+    type = string
+}
+
+variable "customer_logo_url" {
+    type = string
+}
+
+variable "other_logo_url" {
+    type = string
+}
+
+variable "qr_code_os_targets" {
+    type = list(string)
+ }
 provider "launchdarkly" {
   access_token =  var.access_token
 }
@@ -123,7 +138,8 @@ resource "launchdarkly_feature_flag" "release_new_ui" {
   }
 
   tags = [
-    "release"
+    "release",
+    "QR"
   ]
 }
 
@@ -195,11 +211,11 @@ resource "launchdarkly_feature_flag" "config_customer_logo" {
 
   variation_type = "string"
   variations {
-    value       = "https://www.link_to_your_logo.png"
+    value       = var.customer_logo_url
     name        = "Our Logo"
   }
   variations {
-    value       = "https://www.link_to_another_image.png"
+    value       = var.other_logo_url
     name        = "Some Other Image"
   }
 
@@ -376,3 +392,115 @@ resource "launchdarkly_feature_flag" "release_chatbot" {
     "QR"
   ]
 }
+
+resource "launchdarkly_feature_flag_environment" "release_heart_env" {
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.release_heart.key}"
+    env_key = var.environment_key
+
+    on = true
+
+    prerequisites {
+        flag_key = launchdarkly_feature_flag.release_new_ui.key
+        variation = 0
+        }
+    fallthrough {
+        variation = 0
+        }
+    off_variation = 1
+    }
+
+resource "launchdarkly_feature_flag_environment" "show_customer_logo_env"{
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.show_customer_logo.key}"
+    env_key = var.environment_key
+
+    on = true
+
+    prerequisites {
+        flag_key = launchdarkly_feature_flag.release_new_ui.key
+        variation = 0
+        }
+    fallthrough {
+        variation = 0
+        }
+    off_variation = 1
+    }
+
+
+resource "launchdarkly_feature_flag_environment" "release_astronaut_env" {
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.release_astronaut.key}"
+    env_key = var.environment_key
+
+    on = true
+
+    prerequisites {
+        flag_key = launchdarkly_feature_flag.release_new_ui.key
+        variation = 0
+        }
+    fallthrough {
+        variation = 0
+        }
+    off_variation = 1
+    }
+
+resource "launchdarkly_feature_flag_environment" "release_header_logo_env"{
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.release_header_logo.key}"
+    env_key = var.environment_key
+
+    on = true
+
+    prerequisites {
+        flag_key = launchdarkly_feature_flag.release_new_ui.key
+        variation = 0
+        }
+    fallthrough {
+        variation = 0
+        }
+    off_variation = 1
+    }
+
+resource "launchdarkly_feature_flag_environment" "config_background_color_env"{
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.config_background_color.key}"
+    env_key = var.environment_key
+
+    on = true
+    prerequisites {
+        flag_key = launchdarkly_feature_flag.release_new_ui.key
+        variation = 0
+        }
+    fallthrough {
+        variation = 2
+        }
+    off_variation = 0
+    }
+
+resource "launchdarkly_feature_flag_environment" "show_qr_code_env"{
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.show_qr_code.key}"
+    env_key = var.environment_key
+
+    on = true
+    rules {
+        clauses {
+            attribute = "operatingSystem"
+            op = "in"
+            values = var.qr_code_os_targets
+            negate = false
+            }
+        variation = 0
+        }
+    fallthrough {
+        variation = 1
+        }
+    off_variation = 1
+    }
+
+resource "launchdarkly_feature_flag_environment" "config_customer_logo_env"{
+    flag_id = "${var.project_key}/${launchdarkly_feature_flag.config_customer_logo.key}"
+    env_key = var.environment_key
+
+    on = true
+
+    fallthrough {
+        variation = 0
+        }
+    off_variation = 1
+    }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -3,3 +3,15 @@ access_token = "ACCESS_TOKEN_GOES_HERE"
 
 // Key of the LaunchDarkly project wot flags go into
 project_key = "PROJECT_KEY_GOES_HERE"
+
+// Key of the environment intended to be used for the app. e.g., "production"
+environment_key = "ENVIRONMENT_KEY_GOES_HERE"
+
+// URL of two different logos to display. "customer_logo_url" is the on variation
+// "other_logo_url" is the off variation
+customer_logo_url = "https://www.link_to_your_logo.png"
+other_logo_url = "https://www.link_to_another_image.png"
+
+// To ensure QR code is shown only to someone on Desktop (therefore not to people scanning
+// with their phone, set a list of OSs to target)
+qr_code_os_targets = ["Mac OS", "Windows", "Linux"]


### PR DESCRIPTION
This is an update of the flag creation terraform. It does the following:
* Paramaterizes the logo URLs into the tfvars file
* sets the release_new_ui flag as the prereq for release_heart, release_astronaut, show_customer_logo, release_header_logo, and config_background_color
* adds targeting for desktop OSs to show_qr_code so the QR code is displayed for whoever is running the demo on their desktop, but not for people who scan the code on their mobile
* adds "QR" tag to release_new_ui flag